### PR TITLE
[Enhancements] Migrating IP to Country database to IPinfo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm install
       - run: npm test
         env:
-          LICENSE_KEY: ${{ secrets.LICENSE_KEY }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - name: Publish image
         uses: elgohr/Publish-Docker-Github-Action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -30,16 +30,15 @@ Country.is automatically checks for a newer version every 24 hours.
 
 ## Deployment
 
-Use the [hosted service](https://api.country.is) or run privately with
+Use the [hosted service](https://api.country.is) or run privately via the `Dockerfile`.
 
 ```
-docker run -d -p 3000:3000 -e LICENSE_KEY=YOUR_LICENSE_KEY hakanensari/country
+docker build -t country_is .
+docker run -d -p 3000:3000 -e ACCESS_TOKEN=YOUR_ACCESS_TOKEN country_is
 ```
 
-Replace the `YOUR_LICENSE_KEY` placeholder with a license key associated with your MaxMind account.
+Replace the `YOUR_ACCESS_TOKEN` placeholder with an access token key associated with your [IPinfo.io account](https://ipinfo.io/account/token).
 
 ## Notes
 
-Country.is uses geolocation data provided by [Cloudfare](https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation) and [MaxMind](http://dev.maxmind.com/geoip/geoip2/geolite2/).
-
-Since 30 December 2019, you need to [register for a license key](https://www.maxmind.com/en/geolite2/signup) to download the MaxMind data.
+Country.is uses geolocation data provided by [Cloudfare](https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation) and [IPinfo.io](https://ipinfo.io/products/free-ip-database)

--- a/app.js
+++ b/app.js
@@ -5,16 +5,16 @@ const { spawn, spawnSync } = require("child_process"),
   fs = require("fs"),
   maxmind = require("maxmind")
 
-const file = "./data/GeoLite2-Country.mmdb"
+const file = "./data/ipinfo_country.mmdb"
 
 if (!fs.existsSync(file)) {
-  if (process.env.LICENSE_KEY === undefined) {
-    throw new Error("Set a license key to download GeoIP data from MaxMind")
+  if (process.env.ACCESS_TOKEN === undefined) {
+    throw new Error("Get your free IPinfo.io access token to download the IP to Country database")
   }
   spawnSync("./getdb")
 }
 
-if (process.env.LICENSE_KEY) {
+if (process.env.ACCESS_TOKEN) {
   setInterval(() => {
     spawn("./getdb")
   }, 24 * 3600 * 1000)
@@ -26,7 +26,7 @@ const lookup = new maxmind.Reader(fs.readFileSync(file), {
 const findCountry = (ip) => {
   const location = lookup.get(ip)
   if (location && location.country) {
-    return location.country.iso_code
+    return location.country
   }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
       <pre class="content"></pre>
     </div>
 
-    <p>Country.is automatically checks for new MaxMind data every 24 hours.</p>
+    <p>Country.is automatically checks for new IPinfo data every 24 hours.</p>
 
     <h3>Deployment</h3>
     <p>
@@ -98,14 +98,7 @@
         href="https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-IP-geolocation"
         >Cloudfare</a
       >
-      and <a href="https://www.maxmind.com">MaxMind</a>.
-    </p>
-    <p>
-      Since 30 December 2019, you need to
-      <a href="https://www.maxmind.com/en/geolite2/signup"
-        >register for a license key</a
-      >
-      to download the MaxMind data if you're running a private instance.
+      and <a href="https://ipinfo.io">IPinfo</a>.
     </p>
   </body>
 </html>

--- a/getdb
+++ b/getdb
@@ -1,4 +1,5 @@
 #!/bin/sh
 mkdir -p data
 cd data
-curl https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-Country\&suffix=tar.gz\&license_key=$LICENSE_KEY | tar --strip-components 1 -zxf -
+curl -L "https://ipinfo.io/data/free/country.mmdb?token=$ACCESS_TOKEN" -o ipinfo_country.mmdb
+cat ipinfo_country.mmdb


### PR DESCRIPTION
**Context**

The existing IP-to-country database solution does not provide daily updates and has compromised accuracy. [IPinfo's IP-to-country database](https://ipinfo.io/developers/ip-to-country-database) offers full accuracy and is updated daily.

Although the current database is only updated biweekly, our project downloads the database daily.

> The GeoLite2 Country, City, and ASN databases are updated twice weekly, every Tuesday and Friday.
> 

Instead of the current setup, which involves unzipping the geolocation database, we can directly download and use IPinfo's MMDB database.

I have forked the repository and migrated the code references to IPinfo. The IPinfo free IP-to-country database can be used under the CC-BY-SA 4.0 license.